### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/test/java/org/mule/extensions/jms/test/ack/JmsAbstractAckTestCase.java
+++ b/src/test/java/org/mule/extensions/jms/test/ack/JmsAbstractAckTestCase.java
@@ -13,7 +13,7 @@ import org.mule.extensions.jms.api.message.JmsAttributes;
 import org.mule.extensions.jms.test.JmsAbstractTestCase;
 import org.mule.extensions.jms.test.JmsMessageStorage;
 import org.mule.runtime.api.metadata.TypedValue;
-import org.mule.runtime.core.util.func.CheckedSupplier;
+import org.mule.runtime.core.api.util.func.CheckedSupplier;
 import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.tck.junit4.rule.SystemProperty;
 import org.mule.tck.probe.JUnitLambdaProbe;


### PR DESCRIPTION
_ Moving classes to api/internal packages
_ Removing unused code