### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/main/java/org/mule/extensions/jms/internal/source/JmsListener.java
+++ b/src/main/java/org/mule/extensions/jms/internal/source/JmsListener.java
@@ -38,7 +38,7 @@ import org.mule.extensions.jms.internal.support.JmsSupport;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Error;
 import org.mule.runtime.core.api.util.Pair;
-import org.mule.runtime.core.util.StringMessageUtils;
+import org.mule.runtime.core.api.util.StringMessageUtils;
 import org.mule.runtime.extension.api.annotation.Alias;
 import org.mule.runtime.extension.api.annotation.dsl.xml.XmlHints;
 import org.mule.runtime.extension.api.annotation.execution.OnError;


### PR DESCRIPTION
_ Moving more classes to api/internal packages
_ Removing dead code