### PR TITLE
MULE-12903: Every exported Mule package must contain api (part2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,13 @@
             <version>${artemisVersion}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.tests.plugin</groupId>
+            <artifactId>mule-tests-component-plugin</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <classifier>mule-plugin</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>org.mule.tests.plugin</groupId>
             <artifactId>mule-tests-component-plugin</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>${mule.version}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/org/mule/extensions/jms/test/JmsTransactionalTestCase.java
+++ b/src/test/java/org/mule/extensions/jms/test/JmsTransactionalTestCase.java
@@ -16,7 +16,7 @@ import org.mule.runtime.api.message.Error;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.construct.Flow;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 import org.mule.tck.junit4.rule.SystemProperty;
 
 import org.junit.Rule;


### PR DESCRIPTION
MULE-10370: Remove custom-exception-strategy element

_ Moving classes from org.mule.runtime.core.extension to api/internal
_ Temporarily exporting org.mule.runtime.core.internal.extension (because MULE-12427)
_ Adding test:exception-strategy for tests to replace mule:custom-exception-strategy
_ Removing mule:custom-exception-strategy element