### PR TITLE
MULE-12327: ArtifactClassLoaderRunner - Application URLs are also

### DIFF
--- a/src/test/java/org/mule/extensions/jms/test/JmsAbstractTestCase.java
+++ b/src/test/java/org/mule/extensions/jms/test/JmsAbstractTestCase.java
@@ -21,7 +21,7 @@ import static org.mule.runtime.api.metadata.MediaType.ANY;
 import org.mule.extensions.jms.api.destination.JmsDestination;
 import org.mule.extensions.jms.api.message.JmsAttributes;
 import org.mule.extensions.jms.api.message.JmsHeaders;
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.MediaType;

--- a/src/test/java/org/mule/extensions/jms/test/mimeType/JmsMimeTypePropagationTestCase.java
+++ b/src/test/java/org/mule/extensions/jms/test/mimeType/JmsMimeTypePropagationTestCase.java
@@ -15,7 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.mule.extensions.jms.test.JmsAbstractTestCase;
 import org.mule.extensions.jms.test.JmsMessageStorage;
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.core.api.Event;


### PR DESCRIPTION
including transitive dependencies from filter ones
* Cleanup test artifact dependencies so no unwanted transitive
dependencies end up in the APP classloader for tests
* Refactor flowRunner so that test artifact doesn't bring its transitive
dependencies