### PR TITLE
MULE-13132: Add support to access privileged API class from test case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <commonsLangVersion>3.6</commonsLangVersion>
         <guavaVersion>18.0</guavaVersion>
         <springVersion>5.0.0.RELEASE</springVersion>
+        <hawtbufVersion>1.1</hawtbufVersion>
         <muleSpringModuleVersion>1.0.0-SNAPSHOT</muleSpringModuleVersion>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
     </properties>
@@ -67,6 +68,19 @@
             <version>${activemq.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.fusesource.hawtbuf</groupId>
+            <artifactId>hawtbuf</artifactId>
+            <version>${hawtbufVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq.protobuf</groupId>
+            <artifactId>activemq-protobuf</artifactId>
+            <version>${hawtbufVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        
         <!-- Used for in memory broker -->
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/src/test/java/org/mule/extensions/jms/test/JmsAbstractTestCase.java
+++ b/src/test/java/org/mule/extensions/jms/test/JmsAbstractTestCase.java
@@ -21,7 +21,6 @@ import static org.mule.extensions.jms.test.AllureConstants.JmsFeature.JMS_EXTENS
 import static org.mule.extensions.jms.test.JmsMessageStorage.cleanUpQueue;
 import static org.mule.functional.junit4.matchers.MessageMatchers.hasPayload;
 import static org.mule.runtime.api.metadata.MediaType.ANY;
-
 import org.mule.extensions.jms.api.destination.JmsDestination;
 import org.mule.extensions.jms.api.message.JmsAttributes;
 import org.mule.extensions.jms.api.message.JmsHeaders;
@@ -47,8 +46,10 @@ import org.junit.Rule;
 
 @Feature(JMS_EXTENSION)
 @ArtifactClassLoaderRunnerConfig(
-    testInclusions = {"org.apache.activemq:artemis-jms-client"}, sharedRuntimeLibs = {"org.apache.activemq:activemq-client",
-        "org.apache.activemq:activemq-broker", "org.apache.activemq:activemq-kahadb-store", "org.mule.tests:mule-tests-unit"})
+    testInclusions = {"org.apache.activemq:artemis-jms-client"},
+    applicationSharedRuntimeLibs = {"org.apache.activemq:activemq-client",
+        "org.apache.activemq:activemq-broker", "org.apache.activemq:activemq-kahadb-store", "org.fusesource.hawtbuf:hawtbuf",
+        "org.apache.activemq.protobuf:activemq-protobuf"})
 public abstract class JmsAbstractTestCase extends MuleArtifactFunctionalTestCase {
 
   protected static final String NAMESPACE = "JMS";


### PR DESCRIPTION
_ Adding a test-runner plugin to contain test code and access privileged APIs
_ Application's context is created using the application classloader
_ Test is executed using test runner classloader
_ Adding runner configuration attribute to set application libraries (not visible to plugins)
_ Adding runner configuration attribute to set exported libraries from the test runner
_ Extracting mule-test-model artifact form mule-test-unit to contain all the classes that are used from different plugins and needs to be shared from the application
_ Enabling defining mule modules with privileged exported packages but no privileges artifacts