### PR TITLE
MSSBC-112: Fix message receiving when using MS Service Bus and Apache Qpid

### DIFF
--- a/src/main/java/org/mule/extensions/jms/internal/message/JmsMessageUtils.java
+++ b/src/main/java/org/mule/extensions/jms/internal/message/JmsMessageUtils.java
@@ -104,7 +104,7 @@ public class JmsMessageUtils {
           if (value != null) {
             properties.put(key, value);
           }
-        } catch (JMSException e1) {
+        } catch (JMSException | IllegalArgumentException e1) {
           if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("An error occurred while setting a JMS property: ", e1);
           }


### PR DESCRIPTION

When receiving a message from Azure Service Bus using Apache Qpid, the JMS
Connector tries to parse the JMS Message properties. One of the properties
is a java.util.UUID, and when calling message.getObjectPropertu(key) it
throws an IllegalArgumentException, preventing the connector from returning
the message. This is not a fatal error, so I added this exeption to the
try/catch clause that retrieves these properties.
I think you guys contemplated borderline cases like this, but for some
reason the JMS Message is not throwing a JMSException as it should.