### PR TITLE
EE-6639: Adjust outdated dev dependencies versions in some modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <!-- Remove when a new parent version with MTF is available -->
         <munit.input.directory>src/test/munit</munit.input.directory>
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
-        <munit.extensions.maven.plugin.version>1.0.0-SNAPSHOT</munit.extensions.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.0.0-BETA</munit.extensions.maven.plugin.version>
         <munit.version>2.2.0-SNAPSHOT</munit.version>
         <mtf-tools.version>1.0.0-BETA</mtf-tools.version>
         <mavenResources.version>3.0.2</mavenResources.version>


### PR DESCRIPTION
- Changing munit.extensions.maven.plugin.version for one that seems to
 be working