### PR TITLE
Update munit extensions maven plugin and mtf-tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
         <!-- Remove when a new parent version with MTF is available -->
         <munit.input.directory>src/test/munit</munit.input.directory>
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
-        <munit.extensions.maven.plugin.version>1.0.0-SNAPSHOT</munit.extensions.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.0.0-BETA2</munit.extensions.maven.plugin.version>
         <munit.version>2.2.0</munit.version>
-        <mtf-tools.version>1.0.0-SNAPSHOT</mtf-tools.version>
+        <mtf-tools.version>1.0.0-BETA2</mtf-tools.version>
         <mavenResources.version>3.0.2</mavenResources.version>
         <docker.maven.plugin.version>0.25.2</docker.maven.plugin.version>
         <maven.helper.plugin.version>3.0.0</maven.helper.plugin.version>


### PR DESCRIPTION
This commit update munit extensions maven plugin from 1.0.0-SNAPSHOT to 1.0.0-BETA2
and mtf-tools from 1.0.0-SNAPSHOT to 1.0.0-BETA2