### PR TITLE
MULE-17164: map toxiproxy port to dynamically allocated port

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
                                 <portName>activemq.web_console.port</portName>
                                 <portName>connection.lost.port</portName>
                                 <portName>connection.broken.port</portName>
+                                <portName>toxiproxy.port</portName>
                             </portNames>
                         </configuration>
                     </execution>
@@ -351,7 +352,7 @@
                                     <alias>toxiproxy</alias>
                                     <run>
                                         <ports>
-                                            <port>8474:8474</port>
+                                            <port>${toxiproxy.port}:8474</port>
                                             <port>${connection.lost.port}:${connection.lost.port}</port>
                                             <port>${connection.broken.port}:${connection.broken.port}</port>
                                         </ports>


### PR DESCRIPTION
This commits dinamically allocates a port and map it to the toxiproxy port to
avoid fauilures when tests are run concurrently on the same host