### PR TITLE
W-10685928: jms connector concurrency limitation on consume operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <muleSpringModuleVersion>1.3.6</muleSpringModuleVersion>
 
         <formatterConfigPath>formatter.xml</formatterConfigPath>
-        <muleJmsClientVersion>1.13.0</muleJmsClientVersion>
+        <muleJmsClientVersion>1.13.1</muleJmsClientVersion>
         <muleSdkApiVersion>0.3.0</muleSdkApiVersion>
         <mule.http.connector.version>1.5.23</mule.http.connector.version>
 

--- a/src/main/java/org/mule/extensions/jms/internal/operation/JmsConsume.java
+++ b/src/main/java/org/mule/extensions/jms/internal/operation/JmsConsume.java
@@ -20,7 +20,9 @@ import org.mule.extensions.jms.internal.config.JmsConfig;
 import org.mule.extensions.jms.internal.connection.session.JmsSessionManager;
 import org.mule.extensions.jms.internal.metadata.JmsOutputResolver;
 import org.mule.jms.commons.api.AttributesOutputResolver;
+import org.mule.jms.commons.api.message.JmsAttributes;
 import org.mule.jms.commons.internal.connection.JmsTransactionalConnection;
+import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.lifecycle.Initialisable;
 import org.mule.runtime.api.scheduler.SchedulerService;
@@ -40,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 import javax.jms.Destination;
+import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 
@@ -82,23 +85,23 @@ public final class JmsConsume implements Initialisable, Disposable {
    */
   @OutputResolver(output = JmsOutputResolver.class, attributes = AttributesOutputResolver.class)
   @Throws(JmsConsumeErrorTypeProvider.class)
-  public void consume(@Config JmsConfig config,
-                      @Connection JmsTransactionalConnection connection,
-                      @Summary("The name of the Destination from where the Message should be consumed") String destination,
-                      @ConfigOverride @Summary("The Type of the Consumer that should be used for the provided destination") ConsumerType consumerType,
-                      @Optional @Summary("The Session ACK mode to use when consuming a message") ConsumerAckMode ackMode,
-                      @ConfigOverride @Summary("The JMS selector to be used for filtering incoming messages") String selector,
-                      @Optional @Summary("The content type of the message body") @Example(EXAMPLE_CONTENT_TYPE) String contentType,
-                      @Optional @Summary("The encoding of the message body") @Example(EXAMPLE_ENCODING) String encoding,
-                      @Optional(
-                          defaultValue = "10000") @Summary("Maximum time to wait for a message to arrive before timeout") Long maximumWait,
-                      @Optional(
-                          defaultValue = "MILLISECONDS") @Example("MILLISECONDS") @Summary("Time unit to be used in the maximumWaitTime configuration") TimeUnit maximumWaitUnit,
-                      OperationTransactionalAction transactionalAction,
-                      CompletionCallback<Object, Object> result)
-      throws JmsExtensionException {
-    jmsConsume.consume(config, connection, destination, consumerType, ackMode, selector, contentType, encoding, maximumWait,
-                       maximumWaitUnit, transactionalAction, (CompletionCallback) result);
+  public Result<Object, JmsAttributes> consume(@Config JmsConfig config,
+                                               @Connection JmsTransactionalConnection connection,
+                                               @Summary("The name of the Destination from where the Message should be consumed") String destination,
+                                               @ConfigOverride @Summary("The Type of the Consumer that should be used for the provided destination") ConsumerType consumerType,
+                                               @Optional @Summary("The Session ACK mode to use when consuming a message") ConsumerAckMode ackMode,
+                                               @ConfigOverride @Summary("The JMS selector to be used for filtering incoming messages") String selector,
+                                               @Optional @Summary("The content type of the message body") @Example(EXAMPLE_CONTENT_TYPE) String contentType,
+                                               @Optional @Summary("The encoding of the message body") @Example(EXAMPLE_ENCODING) String encoding,
+                                               @Optional(
+                                                   defaultValue = "10000") @Summary("Maximum time to wait for a message to arrive before timeout") Long maximumWait,
+                                               @Optional(
+                                                   defaultValue = "MILLISECONDS") @Example("MILLISECONDS") @Summary("Time unit to be used in the maximumWaitTime configuration") TimeUnit maximumWaitUnit,
+                                               OperationTransactionalAction transactionalAction)
+      throws JmsExtensionException, ConnectionException {
+    return jmsConsume.consume(config, connection, destination, consumerType, ackMode,
+                              selector, contentType, encoding, maximumWait,
+                              maximumWaitUnit, transactionalAction);
   }
 
 

--- a/src/main/java/org/mule/extensions/jms/internal/operation/JmsConsume.java
+++ b/src/main/java/org/mule/extensions/jms/internal/operation/JmsConsume.java
@@ -85,23 +85,23 @@ public final class JmsConsume implements Initialisable, Disposable {
    */
   @OutputResolver(output = JmsOutputResolver.class, attributes = AttributesOutputResolver.class)
   @Throws(JmsConsumeErrorTypeProvider.class)
-  public Result<Object, JmsAttributes> consume(@Config JmsConfig config,
-                                               @Connection JmsTransactionalConnection connection,
-                                               @Summary("The name of the Destination from where the Message should be consumed") String destination,
-                                               @ConfigOverride @Summary("The Type of the Consumer that should be used for the provided destination") ConsumerType consumerType,
-                                               @Optional @Summary("The Session ACK mode to use when consuming a message") ConsumerAckMode ackMode,
-                                               @ConfigOverride @Summary("The JMS selector to be used for filtering incoming messages") String selector,
-                                               @Optional @Summary("The content type of the message body") @Example(EXAMPLE_CONTENT_TYPE) String contentType,
-                                               @Optional @Summary("The encoding of the message body") @Example(EXAMPLE_ENCODING) String encoding,
-                                               @Optional(
-                                                   defaultValue = "10000") @Summary("Maximum time to wait for a message to arrive before timeout") Long maximumWait,
-                                               @Optional(
-                                                   defaultValue = "MILLISECONDS") @Example("MILLISECONDS") @Summary("Time unit to be used in the maximumWaitTime configuration") TimeUnit maximumWaitUnit,
-                                               OperationTransactionalAction transactionalAction)
+  public Result<Object, Object> consume(@Config JmsConfig config,
+                                        @Connection JmsTransactionalConnection connection,
+                                        @Summary("The name of the Destination from where the Message should be consumed") String destination,
+                                        @ConfigOverride @Summary("The Type of the Consumer that should be used for the provided destination") ConsumerType consumerType,
+                                        @Optional @Summary("The Session ACK mode to use when consuming a message") ConsumerAckMode ackMode,
+                                        @ConfigOverride @Summary("The JMS selector to be used for filtering incoming messages") String selector,
+                                        @Optional @Summary("The content type of the message body") @Example(EXAMPLE_CONTENT_TYPE) String contentType,
+                                        @Optional @Summary("The encoding of the message body") @Example(EXAMPLE_ENCODING) String encoding,
+                                        @Optional(
+                                            defaultValue = "10000") @Summary("Maximum time to wait for a message to arrive before timeout") Long maximumWait,
+                                        @Optional(
+                                            defaultValue = "MILLISECONDS") @Example("MILLISECONDS") @Summary("Time unit to be used in the maximumWaitTime configuration") TimeUnit maximumWaitUnit,
+                                        OperationTransactionalAction transactionalAction)
       throws JmsExtensionException, ConnectionException {
-    return jmsConsume.consume(config, connection, destination, consumerType, ackMode,
-                              selector, contentType, encoding, maximumWait,
-                              maximumWaitUnit, transactionalAction);
+    return (Result) jmsConsume.consume(config, connection, destination, consumerType, ackMode,
+                                       selector, contentType, encoding, maximumWait,
+                                       maximumWaitUnit, transactionalAction);
   }
 
 


### PR DESCRIPTION
Consume API changed from a non blocking signature (receives a completion callback and returns void) to a blocking signature (returns the consumed message).